### PR TITLE
patch: CI/CD should fail if user doesn't name PR with proper SemVer bump

### DIFF
--- a/.github/workflows/verify-semver-pr-title.yml
+++ b/.github/workflows/verify-semver-pr-title.yml
@@ -1,0 +1,23 @@
+name: Verify SemVer PR Title
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
+
+jobs:
+  verify-semver-pr-title:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check PR title
+        run: |
+          TITLE="${{ github.event.pull_request.title }}"
+          case "$TITLE" in
+            major:\ *|minor:\ *|patch:\ *) exit 0 ;;
+            *)
+              echo "PR title must start with 'major:', 'minor:' or 'patch:'";
+              exit 1 ;;
+          esac


### PR DESCRIPTION
Open the PR initially without a correct SemVer prefix. Show that it fails.

Then close and reopen the PR with a SemVer prefix that is correct and show the CI/CD pass

ref: #5